### PR TITLE
Create atpi.js

### DIFF
--- a/domains/proj.sbs/atpi.js
+++ b/domains/proj.sbs/atpi.js
@@ -1,0 +1,16 @@
+export default {
+    owner: {
+        // your github username
+        user: "AtlasL1",
+        // your github email
+        email: "loxingle1@gmail.com",
+    },
+    records: [
+        {
+            type: "CNAME",
+            record: "atlasl1.github.io",
+            proxied: false,
+            ttl: 60,
+        }
+    ]
+}


### PR DESCRIPTION
## Requirements

Proj.at reserves the right to review your domain name for approval.

Notes: `proj.at` currently doesn't accept subdomain requests. Please use `proj.sbs`.

- [x] I provided a record file based on the template.
- [x] I have put the record file in the `domains/proj.sbs` folder.
- [x] I promised that I will not use the domain for any illegal activities.
- [x] I promised that this domain is for open-source projects only.
- [x] The record of the subdomain works.
- [x] I have read the [Terms of Service](https://github.com/proj-at/subdomains/wiki/term-of-service).
