### PR TITLE
Create spicydevs.js

### DIFF
--- a/domains/proj.sbs/spicydevs.js
+++ b/domains/proj.sbs/spicydevs.js
@@ -1,0 +1,21 @@
+export default {
+    owner: {
+        // your github username
+        user: "OpAayush",
+        // your github email
+        email: "aayushmagrawal@gmail.com",
+    },
+    records: [
+        // can include multiple records, if some of them conflict, may be overwritten
+        {
+            // type of DNS record
+            type: "CNAME",
+            // content of the record
+            record: "spicydevs.pages.dev",
+            // using Cloudflare CDN
+            proxied: true,
+            // TTL, (s), must be between 60 and 86400
+            ttl: 60,
+        },
+    ]
+}


### PR DESCRIPTION
## Requirements

Proj.at reserves the right to review your domain name for approval.

Notes: `proj.at` currently doesn't accept subdomain requests. Please use `proj.sbs`.

- [x] I provided a record file based on the template.
- [x] I have put the record file in the `domains/proj.sbs` folder.
- [x] I promised that I will not use the domain for any illegal activities.
- [x] I promised that this domain is for open-source projects only.
- [x] The record of the subdomain works.
- [x] I have read the [Terms of Service](https://github.com/proj-at/subdomains/wiki/term-of-service).
