### PR TITLE
Remove the underscore and update the verification entry

### DIFF
--- a/domains/proj.sbs/stduritemplate.js
+++ b/domains/proj.sbs/stduritemplate.js
@@ -14,7 +14,7 @@ export default {
             // Used to verify a domain in the Google Search console to publish the Dart package of:
             // https://github.com/std-uritemplate/std-uritemplate
             type: "TXT",
-            record: "google-site-verification=ITsxQ9eqNNXR6B1vHPgf323lFXFU2W-wtJW_eqavP1w",
+            record: "google-site-verification=XwBh__ofRV59ysU9N7fgpsRxeuYnXos2WpUuPjanu_g",
             ttl: 60,
         },
     ]


### PR DESCRIPTION
Underscores in the domain name are not allowed as verified publishers for Dart 🤷‍♂️ 
Sorry for the noise and thanks again for the service!

cc. @ricardoboss

## Requirements

Proj.at reserves the right to review your domain name for approval.

- [X] I provided a record file based on the template.
- [X] I have put the record file in the `domains/proj.sbs` folder.
- [X] I promised that I will not use the domain for any illegal activities.
- [X] I promised that this domain is for open-source projects only.
- [X] The record of the subdomain works.
- [X] I have read the [Terms of Service](https://github.com/proj-at/subdomains/wiki/term-of-service).
